### PR TITLE
Allow sandbox login.

### DIFF
--- a/src/api/UserApiSF.php
+++ b/src/api/UserApiSF.php
@@ -16,7 +16,7 @@ class UserApiSF
     /**
      * @var string
      */
-    public static $endpoint = 'https://login.salesforce.com/services/Soap/%s/%s';
+    public static $endpoint = 'https://%s.salesforce.com/services/Soap/%s/%s';
 
     /**
      * @param ApiSalesforce $api
@@ -28,9 +28,11 @@ class UserApiSF
     {
         $asWho   = $api->getLoginParams()->amIPartner() ? 'u' : 'c';
         $version = $api->getLoginParams()->getApiVersion();
+        $endpointPrefix = $api->getLoginParams()->getEndpointPrefix();
+        
         $request = new Request(
             'POST',
-            sprintf(self::$endpoint, $asWho, $version),
+            sprintf(self::$endpoint, $endpointPrefix, $asWho, $version),
             [
                 'Content-Type' => 'text/xml; charset=UTF8',
                 'SOAPAction'   => 'login'

--- a/src/conf/LoginParams.php
+++ b/src/conf/LoginParams.php
@@ -32,6 +32,11 @@ class LoginParams extends ConstructFromArrayOrJson
     protected $asPartner = true;
 
     /**
+     * @var string
+     */
+    protected $endpointPrefix = 'login';
+    
+    /**
      * @return string
      */
     public function getUserName()
@@ -140,4 +145,41 @@ class LoginParams extends ConstructFromArrayOrJson
         $this->asPartner = false;
         return $this;
     }
+    
+     /**
+     * @return string
+     */
+    public function getEndpointPrefix()
+        {
+        return $this->endpointPrefix;
+        }
+
+    /**
+     * @return $this
+     */
+    public function setEndpointPrefixAsProduction()
+        {
+        $this->endpointPrefix = 'login';
+        return $this;
+        }
+
+    /**
+     * @return $this
+     */
+    public function setEndpointPrefixAsSandbox()
+        {
+        $this->endpointPrefix = 'test';
+        return $this;
+        }
+
+    /**
+     * @param string $endpointPrefix
+     *
+     * @return $this
+     */
+    public function setEndpointPrefix($endpointPrefix)
+        {
+        $this->endpointPrefix = $endpointPrefix;
+        return $this;
+        }
 }


### PR DESCRIPTION
Currently the user login is hardcoded to "login.salesforce.com".  This allows targeting "test.salesforce.com" for working in sandboxes.