### PR TITLE
Remove API Request Timeout

### DIFF
--- a/src/helpers/ApiHelper.php
+++ b/src/helpers/ApiHelper.php
@@ -23,7 +23,7 @@ class ApiHelper
     public static function getResponse(Request $request, ApiSalesforce $service)
     {
         try {
-            $response = $service->send($request);
+            $response = $service->send($request, [ 'timeout' => 0 ]);
         } catch (\Exception $e) {
             throw new HttpClientException($e->getMessage());
         }


### PR DESCRIPTION
Before: Requests timeout and are termited before completion.
After: Requests are allowed to complete regardless of time taken to run.