### PR TITLE
Update README.md to demonstarte how to access the original data from the returned error list

### DIFF
--- a/src/services/JobSFApiService.php
+++ b/src/services/JobSFApiService.php
@@ -192,6 +192,14 @@ class JobSFApiService
     }
 
     /**
+     * @return SFJob
+     */
+    public function getJob()
+    {
+        return $this->job;
+    }
+
+    /**
      * @return string
      */
     public function getJobId()


### PR DESCRIPTION
# Before
Unable to identify the original data an error referenced when using multiple batches. When adding batches to jobs, there was no way to retreive the Batch Id.

While you could grab a list of Batches in a Job and their Ids via `JobSFApiService::getResults`, the ordering of this list was not stable. Methods such as `JobSFApiService::waitingForComplete` updated the list with an arbitrary order retunred from Salesforce.

# After
Errors from a Job can be referenced back to the orignally uploaded data.

Updated README.md documentation.

# Required code changes
Allow access to SFJob object from JobSFApiService.

# Breaking changes
None


